### PR TITLE
fix: ARM Mac에서 Rosetta 2 호환성 문제 해결

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install fastlane
-        run: brew install fastlane
+        run: arch -arm64 brew install fastlane
 
       # 빌드 및 배포
       - name: Deploy Product to Store
-        run: fastlane release
+        run: arch -arm64 fastlane release
         working-directory: ios
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install fastlane
-        run: brew install fastlane
+        run: arch -arm64 brew install fastlane
 
       # upload key 복호화
       - name: Generate Android keystore
@@ -51,5 +51,5 @@ jobs:
 
       # 빌드 및 배포
       - name: Deploy Product to Store
-        run: fastlane deploy
+        run: arch -arm64 fastlane deploy
         working-directory: android


### PR DESCRIPTION
## Summary
- brew install 및 fastlane 명령에 `arch -arm64` 추가하여 ARM Mac에서 Rosetta 2 호환성 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)