### PR TITLE
chore: 버전 1.0.15 업데이트 및 fastlane 키체인 정리

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -58,5 +58,11 @@ platform :ios do
     upload_to_testflight(
       skip_waiting_for_build_processing: true
     )
+
+  ensure
+    # 임시 키체인 정리
+    if ENV['CI']
+      delete_keychain(name: "fastlane_tmp_keychain") if File.exist?(File.expand_path("~/Library/Keychains/fastlane_tmp_keychain-db"))
+    end
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.14+39
+version: 1.0.15+40
 
 environment:
   sdk: '>=3.2.2 <4.0.0'


### PR DESCRIPTION
## Summary
- 버전 1.0.14+39 → 1.0.15+40 업데이트 (App Store에서 1.0.14가 이미 승인되어 새 빌드 제출 불가)
- fastlane release lane에 `ensure` 블록 추가하여 CI 환경에서 임시 키체인(`fastlane_tmp_keychain`) 자동 정리

## Test plan
- [ ] fastlane release 정상 동작 확인
- [ ] TestFlight 업로드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.15 with improved CI/CD reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->